### PR TITLE
Pillole marzo 2026

### DIFF
--- a/content/articles/acqua-calda-corrente-subito.md
+++ b/content/articles/acqua-calda-corrente-subito.md
@@ -1,0 +1,32 @@
+---
+title: "L'acqua calda corrente subito: un lusso di cui non siamo consapevoli"
+date: 2026-03-01
+tags:
+- acqua calda sanitaria
+- climatizzazione
+- edilizia
+- impianti
+summary: "Tra i tanti lussi che l'abbondanza relativa di combustibili fossili ha garantito fino ad oggi ad un numero elevatissimo di persone c'è l'acqua calda corrente: poco più di 100 anni fa neanche i più ricchi potevano permettersi questo lusso (l'acqua andava scaldata sul fuoco…). Una bella doccia calda quando si vuole, on demand."
+cover_image:
+  src: 
+classes:
+- MWh
+---
+
+Tra i tanti lussi che l'abbondanza relativa di combustibili fossili ha garantito fino ad oggi ad un numero elevatissimo di persone c'è l'acqua calda corrente: poco più di 100 anni fa neanche i più ricchi potevano permettersi questo lusso (l'acqua andava scaldata sul fuoco…). Una bella doccia calda quando si vuole, on demand.
+
+Abbiamo già trattato il tema dei costi energetici di una doccia calda in [questo post](https://resconda.it/articles/vado-a-farmi-una-doccia-calda/). Qui vogliamo quantificare un lusso ancora più "estremo" che la tecnologia (e l'energia a basso costo relativo) negli ultimi 50 anni fino ad oggi ha potuto offrire: l'acqua corrente calda "istantanea".
+
+Forse non tutti sanno che nei sistemi di distribuzione domestica dell'ACS (Acqua Calda Sanitaria) si trova oggi spesso un elemento il cui scopo è, appunto, garantire a chi si vuole lavare dell'acqua calda immediatamente disponibile, appena si apre il rubinetto: la "pompa di ricircolo". Infatti, in una abitazione il rubinetto può essere lontano dall'elemento che scalda l'acqua (caldaia, boiler o altro) e in questo caso, di norma, serve tempo affinché l'acqua arrivi calda.
+
+Tutti abbiamo fatto questa esperienza, tenendo la mano sotto il getto d'acqua prima di mettervi le altre parti del corpo. E chi ha voglia oggi di aspettare 2-3 minuti che l'acqua arrivi calda, che poi magari tocca pensare a qualcosa nel frattempo!
+
+Ma la tecnologia è pronta a venire incontro alle nostre esigenze e inventa il "ricircolo": un circuito idraulico parallelo a quello principale in cui una pompa fa girare costantemente acqua calda, in modo che da questo possa essere immediatamente riversata in quello del rubinetto che viene aperto: l'attesa diventa 2-3 secondi, un successone!
+
+Vediamo qual'è il costo energetico di questo successo.
+
+Cominciamo con un investimento di 1 MWh circa in una rete parallela di 50 m di tubazioni coibentate: 415 kWh per i [tubi e raccordi in acciaio](https://www.greenspec.co.uk/building-design/embodied-energy/#:~:text=The%20UK%20was%20also%20a%20leader%20in,for%20construction%20products%2C%20with%20the%20reported%20climate) (1,5 kg x 50 m x 5,5 kWh/kg), 525 kWh per il rivestimento in polistirene espanso (0,3 kg x 50 m x 35 kWh/kg) + 30 kWh (a forfait…) per la pompa di ricircolo (rame, acciaio, compositi e altro), la centralina di controllo, cavi elettrici, etc.
+
+A questo punto vediamo gli e-costi operativi, che sono di due tipi: l'energia consumata dal pompa di ricircolo e l'energia termica dissipata attraverso i tubi. I primi sono di norma bassi: con un consumo di 5W in un anno di uso anche continuo fa meno di 45 kWh. Il grosso del consumo è infatti causato dalla dispersione del calore dell'acqua calda sanitaria attraverso i tubi del sistema di ricircolo e della conseguente necessità per la centrale termica di riscaldarla in continuo. Qui è veramente difficile fare delle stime, che dipendono da molti fattori (coibentazione del sistema e della casa, tipo di riscaldamento dell'ACS, orari di attività del sistema, etc.), Inoltre se il calore disperso nell'abitazione dal sistema in inverno può contribuire a ridurre il costo energetico della climatizzazione, in estate può causarne un incremento (per il condizionamento). Secondo [questo studio](https://www.caleffi.com/sites/default/files/media/external-file/Idraulica_53_IT_Le%20pompe%20di%20circolazione.pdf) tale consumo energetico può variare tra 25.500 e 127.500 kWh all'anno, per una rete condominiale di 6 appartamenti.
+
+Se i numeri dello studio sono corretti si tratta di un impatto enorme: se consideriamo che un'abitazione di 100 mq in classe A ha un consumo di energia per riscaldamento pari a 2000 kWh/anno, il lusso dell'acqua istantanea al rubinetto può far schizzare questo valore a 22.000 kWh! Un valore che è superiore al consumo di un'abitazione in classe G (16.000 kWh/anno), ma in cui, di tanto in tanto, si passano 2-3 minuti davanti al rubinetto. Magari a pensare.

--- a/content/articles/per-un-pugno-di-coriandoli.md
+++ b/content/articles/per-un-pugno-di-coriandoli.md
@@ -1,0 +1,45 @@
+---
+title: "Per un pugno di coriandoli. Energia che "investiamo" nel Carnevale"
+date: 2026-03-01
+tags:
+- Coriandoli
+- Carnevale
+- Carta
+summary: "Leggeri come l'aria quando li lanciamo, ma assai meno dal punto di vista energetico: i coriandoli del Carnevale italiano richiedono circa 4,5 GWh di energia per essere prodotti!"
+cover_image:
+  src: 
+classes:
+- kWh
+---
+
+L'usanza di scagliare in aria piccoli oggetti è una tradizione ereditata dagli antichi greci, che gettavano foglie e petali di fiori (ma anche rametti o gusci d'uovo ripieni di essenze) agli atleti vittoriosi o agli eroi di guerra, sui defunti nei cortei funebri e agli sposi nei banchetti nuziali. Durante il Rinascimento si ricoprono di zucchero i semi di coriandolo (la spezia) per trasformarli in piccoli confetti da lanciare dal balcone o dai carri durante i festeggiamenti carnevaleschi: da qui il nome "coriandoli".
+
+Ogni anno, tra febbraio e marzo, l'Italia si copre di un coloratissimo manto di coriandoli. È un gesto innocente: una manciata lanciata in aria, un paio di risate, qualche foto. Poi il vento, la pioggia (e il lavoro delle amministrazioni comunali) li portano via e tutto sembra svanire.
+
+Dietro quei piccoli dischetti colorati si nasconde un processo industriale sorprendentemente energivoro. Proviamo a quantificarlo.
+
+Cosa sono davvero i coriandoli? La maggior parte è fatta di carta riciclata: vecchi giornali, scarti tipografici, cartoncino da macero. È la versione "buona", quella che si biodegrada in tempi ragionevoli e ha un'energia incorporata relativamente bassa: circa 1 kWh per kg di carta riciclata.
+
+Poi ci sono i coriandoli "premium", come quelli di aziende specializzate tipo [Karnaval](https://www.karnaval.it/). Perfetti, uniformi, resistenti, splendidamente colorati e… realizzati in carta vergine di alta qualità. Bellissimi da vedere, ma con un costo energetico che cresce parecchio: la produzione della carta vergine richiede infatti 8–11 kWh per kg. Insomma: la bellezza si paga, e in questo caso… in kilowattora.
+
+Quanta energia serve davvero a produrli? Oltre alla carta, bisogna considerare il processo industriale: taglio in strisce - colorazione (quando necessaria) - fustellatura in milioni di piccoli dischetti - essiccazione - confezionamento. Tutta la catena aggiunge circa 0,4 kWh per kg, indipendentemente dal tipo di carta. Complessivamente otteniamo:
+
+coriandoli riciclati → ~ 1,4–1,8 kWh per kg
+
+coriandoli in carta vergine → ~ 8,5–11,5 kWh per kg
+
+Per semplificare: una busta da 150 g costa tra 0,2 e 1,7 kWh, a seconda della qualità. La differenza tra un Carnevale eco-friendly e uno energivoro è più ampia di quanto pensi.
+
+Quanti ne usiamo in Italia? Non esistono dati ufficiali, ma una stima realistica si può fare.
+
+- Numero di bambini tra i 3–12 anni in Italia: 5 milioni
+- Consumo medio per bambino a Carnevale: 100–300 g
+- Eventi e sfilate pubbliche: 200–300 tonnellate l'anno
+
+Stima prudente: **900–1.100 tonnellate di coriandoli usati ogni anno**.
+
+Per stimare questo totale, assumiamo un mix 70% riciclato – 30% vergine, ottenendo quindi un'energia media di 4,5 kWh per kg. Con 1000 tonnellate stimate **si ottiene un valore di circa 4,5 GWh,** equivalente al **consumo elettrico annuale di 1.500 famiglie italiane.**
+
+Un gesto leggero che pesa, buttato per aria. Letteralmente.
+
+È chiaro: i coriandoli non sono il vero problema ambientale del paese. Ma sono un esempio affascinante di come anche le cose più "piccole" abbiano una storia energetica sorprendente. Un'idea semplice per ridurre l'impatto? Preferire coriandoli in carta riciclata, privi di plastica e coloranti non biodegradabili. Oppure — eresia — usarne un po' meno. Perché sì, sono leggeri, ma solo quando li tieni in mano. Dal punto di vista energetico pesano eccome.

--- a/content/articles/per-un-pugno-di-coriandoli.md
+++ b/content/articles/per-un-pugno-di-coriandoli.md
@@ -1,5 +1,5 @@
 ---
-title: "Per un pugno di coriandoli. Energia che "investiamo" nel Carnevale"
+title: 'Per un pugno di coriandoli. Energia che \"investiamo\" nel Carnevale'
 date: 2026-03-01
 tags:
 - Coriandoli

--- a/content/spuntini/petrolio-e-maccheroni.md
+++ b/content/spuntini/petrolio-e-maccheroni.md
@@ -1,0 +1,25 @@
+---
+title: "Petrolio e maccheroni"
+date: 2026-03-01
+tags:
+- spuntini
+summary: "Purtroppo la domanda globale di combustibili fossili è tipicamente anelastica: si tratta di beni insostituibili nel breve termine. Quindi a fronte di quelli (pochi) che gioiscono, molti altri si preoccupano, perché il petrolio (il gas, il carbone…) costituiscono, volenti o nolenti, la base della nostra società ed economia."
+---
+
+Nei giorni scorsi il Ministro degli Esteri iraniano ha preconizzato una crescita del prezzo del petrolio fino a 300 USD al barile quale possibile conseguenza del blocco del traffico nello stretto di Hormuz. Un aumento del prezzo dei combustibili fossili è visto con favore dai molti che prosperano sul consumo di energia fossile e che vedono così aumentare i margini di guadagno. Se ne avvantaggiano sia coloro che normalmente hanno difficoltà a vendere il proprio petrolio (ad esempio il petrolio Venezuelano, che è tanto ma di scarsa qualità, oppure quello da fracking con processi di estrazione costosi), sia quelli dotati di tanto petrolio e a basso prezzo (medio oriente), che vedono i margini aumentare. Ne beneficiano anche autocrati come Putin, che vede aprirsi maggiori opportunità di vendita dei propri combustibili.
+
+Purtroppo la domanda globale di combustibili fossili è tipicamente anelastica: si tratta di beni insostituibili nel breve termine. Quindi a fronte di quelli (pochi) che gioiscono, molti altri si preoccupano, perché il petrolio (il gas, il carbone…) costituiscono, volenti o nolenti, la base della nostra società ed economia.
+
+Non si tratta solo del costo del riscaldamento domestico o della benzina alla pompa, temi che emergono sui giornali e che vengono percepiti come più vicini dalle persone: l'aumento del prezzo dei combustibili incide su tutto: sui costi di produzione del cibo (da un punto di vista energetico più del 90% dell'energia contenuta in un piatto di pasta è di fonte fossile, ne abbiamo parlato [qui](https://resconda.it/articles/un-bel-piatto-di-petrolio-alle-vongole/)), dei prodotti industriali, dei servizi, della sanità, dell'educazione…
+
+La nostra è una società il cui modello organizzativo e sociale, la cui stessa esistenza, si basano sulla ampia disponibilità di combustibili fossili a basso costo.
+
+Lo stretto di Hormuz a un certo punto riaprirà ed il prezzo scenderà nuovamente, tuttavia la disponibilità reale di combustibili fossili a basso costo va comunque riducendosi - certamente ed inevitabilmente - ed i costi reali sono destinati a crescere (al di là della dinamica dei prezzi, che dipende da fattori umani ed imprevedibili). I costi da sostenere per rendere disponibili tali combustibili dipendono infatti da fattori fisici e termodinamici, sui quali non è possibile nella sostanza intervenire. Negli anni 50' un geologo della Shell di nome [Marion King Hubbert](https://it.wikipedia.org/wiki/Picco_di_Hubbert) ha chiarito una delle conseguenze di ciò: le risorse non rinnovabili finiscono (sembra lapalissiano ma ancora oggi c'è chi non ci crede), mentre Charles H. Hall (che abbiamo avuto il piacere di avere ospite in [un Convegno](https://resconda.it/articles/spuntini/emcoin-a-cinemambiente/) organizzato da Resconda due anni fa), insieme a molti altri, ha spiegato come e perchè continuare a sostenere un modello di società ed economia basata sulla crescita dei consumi (grazie anche all'illusionismo di un crescente debito pubblico e privato) e sui combustibili fossili, costituisca una lucida follia.
+
+Tutto ciò, sottolineiamo, anche indipendentemente dagli effetti devastanti che il consumo di combustibili fossili ha sull'ambiente e sul clima.
+
+Rinunciare progressivamente ai combustibili fossili (e sostituirli con fonti energetiche rinnovabili) non solo è possibile (anche se sicuramente non senza aggiustamenti nel modello sociale ed economico attuale), ma è anche necessario. E allo stesso tempo è anche inevitabile.
+
+Per fare 500 g di maccheroni con una impastatrice ed un estrusore manuali servono (oltre agli ingredienti) circa 1,5 ore di lavoro di un uomo robusto, oppure una pari quantità di energia, contenuta in circa 2 centilitri di petrolio (il contenuto di una siringa). Oggi grazie al petrolio possiamo comprare al supermercato un pacco da mezzo chilo di maccheroni pagandolo 1 euro invece di 20 (dovendo retribuire il lavoro).
+
+Non è un caso se 150 anni fa solo pochi ricchi mangiavano maccheroni, gli altri solo polenta o simili.


### PR DESCRIPTION
4 Pillole + 1 Spuntino di marzo 2026.

**Articoli:**
- La potenza del cavallo
- Per un pugno di coriandoli
- L'acqua calda corrente subito
- Bomboloni alla crema, sport ed energia

**Spuntino:**
- Petrolio e maccheroni

⚠️ Le immagini di copertina (`cover_image.src`) vanno ancora caricate su Cloudinary e inserite manualmente nei frontmatter.