### PR TITLE
Search tags

### DIFF
--- a/assets/style.scss
+++ b/assets/style.scss
@@ -563,6 +563,9 @@ ul.cloud {
   line-height: 1.1rem;
   li {
     margin-bottom: 0px;
+    a.tag-highlight {
+        background-color: $primary;
+    }
   }
   /* this shows the counter next to the tag label */
   // &[data-show-value] a::after {

--- a/layouts/tags/terms.html
+++ b/layouts/tags/terms.html
@@ -4,15 +4,13 @@
 {{ define "main" }}
 <div class="container-fluid">
     <h2 class="site-title">Tutti i tag</h2>
+    <div class="text-center my-4">
+        <input class="form-control" type="text" id="searchTags" placeholder="Cerca tags" />
+    </div>
     <!-- list template -->
-        {{ partial "tag-cloud.html" }}
-        <!-- {{ range $idx, $tag := .Site.Taxonomies.tags.ByCount }}
-        <div class="h{{math.Min 6 (math.Add $idx 1)}}">
-            {{ with site.GetPage (path.Join "tags" .Name )}}
-            <a href="{{.RelPermalink}}">{{.LinkTitle}}</a> <span class="badge rounded-pill bg-secondary" style="font-size:smaller;"> &nbsp;{{- $tag.Count -}}&nbsp; </span>
-            {{ end }}
-        </div>
-        {{ end }} -->
-
+    {{ partial "tag-cloud.html" }}
 </div>
+{{ end }}
+{{ define "footer_scripts" }}
+<script src="/js/tags.js"></script>
 {{ end }}

--- a/layouts/tags/terms.html
+++ b/layouts/tags/terms.html
@@ -12,5 +12,5 @@
 </div>
 {{ end }}
 {{ define "footer_scripts" }}
-<script src="/js/tags.js"></script>
+<script src={{ relURL "js/tags.js" }}></script>
 {{ end }}

--- a/static/js/tags.js
+++ b/static/js/tags.js
@@ -1,0 +1,23 @@
+window.addEventListener("load", () => {
+    document.getElementById("searchTags")?.addEventListener("keyup", (event) => {
+        var searchTerm = event.target.value.toLowerCase();
+        var items = document.querySelectorAll("ul.cloud li a");
+        if(searchTerm.length > 2){
+            // loop over all tag items and highlight those matching the search term
+            items.forEach(function (item, currentIndex, listObj) {
+                let currentValue = item.text.toLowerCase();
+                if( currentValue.search(searchTerm) >= 0) {
+                    // matches
+                    item.classList.add("tag-highlight");
+                }else {
+                    item.classList.remove("tag-highlight");
+                }
+            });
+        }else{
+            // remove highlighting from all items
+            items.forEach(function (item, currentIndex, listObj) {
+                item.classList.remove("tag-highlight");
+            });
+        }
+    });
+});


### PR DESCRIPTION
Add search feature to the `/tags` page.  
The user types a search term in the search bar on top of the page. When the term is at least 3 chararcters long, the script loops over the `<li><a>` items in the tag cloud, and adds a `.tag-highlight` class to the html element.